### PR TITLE
clone URL rectified.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ I've only tested it on OSX so any contributions or bugfixes welcome.
 
 brew install imagemagick
 brew install ttyrec
-git clone git@github.com:michaeldfallen/terminal-gif.git
+git clone https://github.com/michaeldfallen/terminal-gif.git
 
 
 ```


### PR DESCRIPTION
clone URL was not a public one. Only the actual owner of the repository can clone using that specific URL.
It was replaced with the correct one.
